### PR TITLE
Context Search tiddler as shadow

### DIFF
--- a/plugins/contextPlugin/styles.css.tid
+++ b/plugins/contextPlugin/styles.css.tid
@@ -1,5 +1,5 @@
 created: 20140529162823729
-tags: $:/tags/Stylesheet contextPlugin
+tags: $:/tags/Stylesheet
 title: $:/plugins/danielo515/ContextPlugin/Stylesheet/results
 type: text/css
 

--- a/plugins/contextPlugin/tiddler/Caption.tid
+++ b/plugins/contextPlugin/tiddler/Caption.tid
@@ -1,5 +1,4 @@
 created: 20140530174219263
-tags: contextPlugin
 title: $:/plugins/danielo515/ContextPlugin/Caption
 type: text/vnd.tiddlywiki
 

--- a/plugins/contextPlugin/tiddler/Context Search.tid
+++ b/plugins/contextPlugin/tiddler/Context Search.tid
@@ -2,7 +2,7 @@ caption: {{$:/plugins/danielo515/ContextPlugin/Caption}}
 created: 20140530173407542
 modified: 20220326092807788
 tags: $:/tags/AdvancedSearch
-title: Context Search
+title: $:/plugins/danielo515/ContextPlugin/ContextSearch
 type: text/vnd.tiddlywiki
 
 \define lingo-base() $:/language/Search/

--- a/plugins/contextPlugin/tiddler/readme.tid
+++ b/plugins/contextPlugin/tiddler/readme.tid
@@ -3,7 +3,7 @@ This widget works as regular search and shows the result with the searched word 
 
 !Usage
 
-After installing the plugin you will have a new tab in [[$:/AdvancedSearch]] called [[Context Search]]. If you want this functionality in other places you will have to edit the desired tiddler yourself adding the ''context widget''. For more details about using the widget see the section below.
+After installing the plugin you will have a new tab in [[$:/AdvancedSearch]] called [[Context Search|$:/core/ui/AdvancedSearch/Standard]]. If you want this functionality in other places you will have to edit the desired tiddler yourself adding the ''context widget''. For more details about using the widget see the section below.
 
 !!Using the widget
 
@@ -24,7 +24,7 @@ The widgets will search inside the current tiddler by default. Because that you 
 </$list>
 ```
 
-That will search for tiddlers containing the text specified in [[$:/temp/advancedsearch]] and will display a link to the matching tiddlers plus a preview of the matching content. Something very similar is used in [[Context Search]]. Below you can find a complete list of parameters and their default values.
+That will search for tiddlers containing the text specified in [[$:/temp/advancedsearch]] and will display a link to the matching tiddlers plus a preview of the matching content. Something very similar is used in [[Context Search|$:/core/ui/AdvancedSearch/Standard]]. Below you can find a complete list of parameters and their default values.
 
 |! parameter |! description | !default |
 | term | The term you want to search ||


### PR DESCRIPTION
Hello, first thanks by the great plugin. I use this in multiples wikis.

IMO, the Context Search tiddler can get messed up in the middle of user tiddlers. Without shadow's name, it can be listed in Recent tab or show in search if modified (like for add a list-after field, for change the order's tab in the Advanced Search).